### PR TITLE
added a more robust read-keys function that can capture output from complex keys

### DIFF
--- a/chooser.sh
+++ b/chooser.sh
@@ -98,7 +98,7 @@ while :;do
                 cursor_down
             fi
             ;;
-        ""|$'\n'|$'\x0a') # TODO: fix this, pressing ctrl+j and some other keys triggers this case 
+        $'\n'|$'\x0a') # TODO: fix this, pressing ctrl+j and some other keys triggers this case 
             sel=${choices[actual_pos]} ; exit 0 ;;
     esac
 done

--- a/chooser.sh
+++ b/chooser.sh
@@ -73,13 +73,13 @@ cursor=$offset
 (( (total_choices - pos) >= ROWS )) && printf '\e[%d;1H▼' "$((ROWS + offset))"
 trap cleanup EXIT
 while :;do
-    # fixes exiting when holding down keys
     ((actual_pos = cursor - offset + pos)) || true
     list_choices
+    # fixes exiting when holding down keys
     read_keys
     sleep 0.0001
     case "${KEY}" in
-        k|$'\x1b\x5b\x42')
+        k|$'\x1b\x5b\x41')
             if (( cursor == offset )) && (( pos > 0 ));then
                 ((pos-=1))
             elif (( cursor > offset ));then
@@ -87,7 +87,7 @@ while :;do
                 cursor_up
             fi
             ;;
-        j|$'\x1b\x5b\x41')
+        j|$'\x1b\x5b\x42')
             (( actual_pos == (total_choices - 1) )) && continue # TODO: fix this, unecessary logic?
             if (( cursor == (ROWS + offset - 1) )) && (( (total_choices - pos) != ROWS ))
             then

--- a/chooser.sh
+++ b/chooser.sh
@@ -98,6 +98,8 @@ while :;do
                 cursor_down
             fi
             ;;
+        $'\x1b') # ESC key
+            exit 0 ;;
         $'\n'|$'\x0a') # TODO: fix this, pressing ctrl+j and some other keys triggers this case 
             sel=${choices[actual_pos]} ; exit 0 ;;
     esac

--- a/chooser.sh
+++ b/chooser.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+# set -e
 
 # Resources:
 #   https://espterm.github.io/docs/VT100%20escape%20codes.html
@@ -18,7 +18,21 @@ cursor_up(){ printf '\e[A'; }
 cursor_down(){ printf '\e[B'; }
 cursor_save(){ printf '\e7'; }
 cursor_restore(){ printf '\e8'; }
-read_keys(){ read -rsn1 KEY </dev/tty; }
+# read_keys(){ read -rsn1 KEY </dev/tty; }
+read_keys(){
+    unset K1 K2 K3
+    # shellcheck disable=2162
+    read -sN1 </dev/tty
+    K1="$REPLY"
+    # shellcheck disable=2162
+    read -sN2 -t 0.001 </dev/tty
+    K2="$REPLY"
+    # shellcheck disable=2162
+    read -sN1 -t 0.001 </dev/tty
+    K3="$REPLY"
+    # this will read full keysets like 'enter' and 'space' instead of just j or k
+    KEY="$K1$K2$K3"
+}
 set_offset() { IFS='[;' read -p $'\e[6n' -d R -rs _ offset _ _ </dev/tty; }
 cleanup() {
     printf '\e[%d;1H' "$offset"
@@ -38,7 +52,7 @@ list_choices() {
 
 declare -a choices=()
 if [ "$1" = - ];then
-    while read -r i;do choices+=("$i") ;done
+    while read -r i; do choices+=("$i"); done
 else 
     choices=("$@")
 fi
@@ -50,15 +64,8 @@ pos=0
 total_choices=${#choices[@]}
 ((ROWS = (LINES / 2) + 1))
 set_offset
-if (( (offset + ROWS) >= LINES )) && (( total_choices >= ROWS ));then # TODO: is this needed?
-    # if the offset (starting cursor position) + ROWS goes beyond LINES and
-    # we have more choices than the number of ROWS change the offset to what it will be
-    # after listing the choices.
-    if (( offset == LINES ));then
-        printf '\e[%d;1H' "$((offset - ROWS))";
-    else
-        printf '\e[%d;1H' "$((offset - ROWS + 1))";
-    fi
+if (( (offset + ROWS) > LINES )) && (( total_choices >= ROWS ));then # TODO: don't do this?
+    printf '\e[%d;1H' "$((offset - ROWS + 1))";
     set_offset
 fi
 cursor=$offset
@@ -66,30 +73,33 @@ cursor=$offset
 (( (total_choices - pos) >= ROWS )) && printf '\e[%d;1H▼' "$((ROWS + offset))"
 trap cleanup EXIT
 while :;do
-    actual_pos=$((cursor - offset + pos))
+    # fixes exiting when holding down keys
+    ((actual_pos = cursor - offset + pos)) || true
     list_choices
     read_keys
+    sleep 0.0001
     case "${KEY}" in
-        k)
+        k|$'\x1b\x5b\x42')
             if (( cursor == offset )) && (( pos > 0 ));then
-                pos=$((pos - 1))
+                ((pos-=1))
             elif (( cursor > offset ));then
-                cursor=$((cursor - 1))
+                ((cursor-=1))
                 cursor_up
             fi
             ;;
-        j)
+        j|$'\x1b\x5b\x41')
             (( actual_pos == (total_choices - 1) )) && continue # TODO: fix this, unecessary logic?
             if (( cursor == (ROWS + offset - 1) )) && (( (total_choices - pos) != ROWS ))
             then
-                pos=$((pos + 1))
+                ((pos+=1))
             elif (( cursor < (ROWS + offset - 1) ))
             then
-                cursor=$((cursor + 1))
+                ((cursor+=1))
                 cursor_down
             fi
             ;;
-        '') # TODO: fix this, pressing ctrl+j and some other keys triggers this case 
+        ""|$'\n'|$'\x0a') # TODO: fix this, pressing ctrl+j and some other keys triggers this case 
             sel=${choices[actual_pos]} ; exit 0 ;;
     esac
 done
+


### PR DESCRIPTION
Allows the use of keys like Enter, Up_arrow, Down_arrow, ESC, F1 etc... and implemented Enter, UP and DOWN arrows in the case statement as valid controls. Had to disable error exit / set -e / for this to work however. Looking for a workaround. This pull request addresses the TODO at the end of the file about ctrl+j triggering the choice as well.